### PR TITLE
Add MNIST cGAN training and Streamlit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# METI
+# MNIST Handwritten Digit Generator
+
+This project contains a simple conditional GAN (cGAN) trained from scratch on the MNIST dataset and a Streamlit web app to generate handwritten digits.
+
+## Training
+Run the training script to create `mnist_cgan_generator.pth`:
+
+```bash
+python mnist_gan_training.py
+```
+
+Training requires a GPU for reasonable speed and downloads the MNIST dataset automatically.
+
+## Web App
+After training, launch the Streamlit app:
+
+```bash
+streamlit run app.py
+```
+
+Select a digit (0-9) and click **Generate 5 Images** to see examples from the trained generator.
+
+Deploy the app to Streamlit Community Cloud or similar platforms by uploading `app.py`, `requirements.txt`, and the saved model weights.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,58 @@
+import streamlit as st
+import torch
+import torch.nn as nn
+import numpy as np
+from PIL import Image
+
+# Hyperparameters should match training
+noise_dim = 100
+embedding_dim = 10
+hidden_dim = 256
+
+class Generator(nn.Module):
+    def __init__(self, noise_dim, embedding_dim, num_classes=10):
+        super().__init__()
+        self.label_emb = nn.Embedding(num_classes, embedding_dim)
+        input_dim = noise_dim + embedding_dim
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.ReLU(True),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(True),
+            nn.Linear(hidden_dim, 28*28),
+            nn.Tanh()
+        )
+
+    def forward(self, noise, labels):
+        x = torch.cat([noise, self.label_emb(labels)], dim=1)
+        out = self.net(x)
+        return out
+
+@st.cache_resource
+def load_generator(path='mnist_cgan_generator.pth'):
+    device = torch.device('cpu')
+    G = Generator(noise_dim, embedding_dim).to(device)
+    G.load_state_dict(torch.load(path, map_location=device))
+    G.eval()
+    return G
+
+def generate_images(generator, digit, num_images=5):
+    device = next(generator.parameters()).device
+    noise = torch.randn(num_images, noise_dim, device=device)
+    labels = torch.full((num_images,), digit, dtype=torch.long, device=device)
+    with torch.no_grad():
+        imgs = generator(noise, labels)
+    imgs = imgs.view(num_images, 28, 28)
+    imgs = (imgs + 1) / 2  # [-1,1] -> [0,1]
+    imgs = imgs.mul(255).clamp(0, 255).byte().cpu().numpy()
+    return imgs
+
+st.title("MNIST Handwritten Digit Generator")
+
+digit = st.selectbox("Select digit", list(range(10)), index=0)
+if st.button("Generate 5 Images"):
+    G = load_generator()
+    images = generate_images(G, int(digit), num_images=5)
+    cols = st.columns(5)
+    for col, img in zip(cols, images):
+        col.image(Image.fromarray(img, mode='L'), caption=f"Digit {digit}")

--- a/mnist_gan_training.py
+++ b/mnist_gan_training.py
@@ -1,0 +1,120 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torchvision import datasets, transforms
+from torch.utils.data import DataLoader
+
+# Hyperparameters
+noise_dim = 100
+embedding_dim = 10
+hidden_dim = 256
+batch_size = 128
+epochs = 30
+lr = 2e-4
+
+# Dataset
+transform = transforms.Compose([
+    transforms.ToTensor(),
+    transforms.Normalize((0.5,), (0.5,))
+])
+
+dataset = datasets.MNIST(root='data', train=True, download=True, transform=transform)
+dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
+
+# Models
+class Generator(nn.Module):
+    def __init__(self, noise_dim, embedding_dim, num_classes=10):
+        super().__init__()
+        self.label_emb = nn.Embedding(num_classes, embedding_dim)
+        input_dim = noise_dim + embedding_dim
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.ReLU(True),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(True),
+            nn.Linear(hidden_dim, 28*28),
+            nn.Tanh()
+        )
+
+    def forward(self, noise, labels):
+        x = torch.cat([noise, self.label_emb(labels)], dim=1)
+        out = self.net(x)
+        return out
+
+class Discriminator(nn.Module):
+    def __init__(self, embedding_dim, num_classes=10):
+        super().__init__()
+        self.label_emb = nn.Embedding(num_classes, embedding_dim)
+        self.net = nn.Sequential(
+            nn.Linear(28*28 + embedding_dim, hidden_dim),
+            nn.LeakyReLU(0.2, inplace=True),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.LeakyReLU(0.2, inplace=True),
+            nn.Linear(hidden_dim, 1),
+            nn.Sigmoid()
+        )
+
+    def forward(self, images, labels):
+        x = torch.cat([images, self.label_emb(labels)], dim=1)
+        out = self.net(x)
+        return out
+
+def weights_init(m):
+    if isinstance(m, nn.Linear):
+        nn.init.normal_(m.weight, 0.0, 0.02)
+        nn.init.constant_(m.bias, 0)
+
+
+def train():
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    G = Generator(noise_dim, embedding_dim).to(device)
+    D = Discriminator(embedding_dim).to(device)
+    G.apply(weights_init)
+    D.apply(weights_init)
+
+    criterion = nn.BCELoss()
+    optim_G = optim.Adam(G.parameters(), lr=lr, betas=(0.5, 0.999))
+    optim_D = optim.Adam(D.parameters(), lr=lr, betas=(0.5, 0.999))
+
+    fixed_noise = torch.randn(10, noise_dim, device=device)
+    fixed_labels = torch.arange(10, device=device)
+
+    for epoch in range(1, epochs + 1):
+        for real_imgs, real_labels in dataloader:
+            batch_size_curr = real_imgs.size(0)
+            real_imgs = real_imgs.view(batch_size_curr, -1).to(device)
+            real_labels = real_labels.to(device)
+
+            # Train Discriminator
+            z = torch.randn(batch_size_curr, noise_dim, device=device)
+            fake_labels = torch.randint(0, 10, (batch_size_curr,), device=device)
+            fake_imgs = G(z, fake_labels)
+
+            real_targets = torch.ones(batch_size_curr, 1, device=device)
+            fake_targets = torch.zeros(batch_size_curr, 1, device=device)
+
+            D_real = D(real_imgs, real_labels)
+            D_fake = D(fake_imgs.detach(), fake_labels)
+
+            loss_real = criterion(D_real, real_targets)
+            loss_fake = criterion(D_fake, fake_targets)
+            loss_D = (loss_real + loss_fake) / 2
+
+            optim_D.zero_grad()
+            loss_D.backward()
+            optim_D.step()
+
+            # Train Generator
+            D_fake_for_G = D(fake_imgs, fake_labels)
+            loss_G = criterion(D_fake_for_G, real_targets)
+
+            optim_G.zero_grad()
+            loss_G.backward()
+            optim_G.step()
+
+        print(f"Epoch [{epoch}/{epochs}] Loss_D: {loss_D.item():.4f} Loss_G: {loss_G.item():.4f}")
+
+    torch.save(G.state_dict(), 'mnist_cgan_generator.pth')
+
+if __name__ == '__main__':
+    train()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+streamlit
+torch
+torchvision
+numpy
+pillow


### PR DESCRIPTION
## Summary
- implement a cGAN training script for MNIST
- create a Streamlit app to generate digits
- add Python dependencies and instructions

## Testing
- `python -m py_compile mnist_gan_training.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_68570debfe2c832e9839c47cf85f68d0